### PR TITLE
chore: add unused openai dependency

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -1,10 +1,9 @@
 import type { KnipConfig } from "knip";
 
 const config: KnipConfig = {
-  entry: ["build/index.ts"],
-  project: ["src/**/*.ts"],
-  ignore: ["src/types/config.ts"],
-  ignoreExportsUsedInFile: true,
+  entry: ["static/scripts/key-generator/keygen.ts"],
+  project: ["static/**/*.ts"],
+  ignoreExportsUsedInFile: false,
   ignoreDependencies: ["libsodium-wrappers", "eslint-config-prettier", "eslint-plugin-prettier"],
 };
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-sonarjs": "^0.24.0",
     "husky": "^9.0.11",
     "knip": "^5.0.1",
+    "openai": "^4.2.1",
     "lint-staged": "^15.2.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",


### PR DESCRIPTION
qa